### PR TITLE
handle s3_permissions at write time, not and url generation time - always use https

### DIFF
--- a/lib/dm-paperclip/storage/s3.rb
+++ b/lib/dm-paperclip/storage/s3.rb
@@ -109,7 +109,7 @@ module Paperclip
           @bucket         = @bucket.call(self) if @bucket.is_a?(Proc)
           @s3_options     = @options[:s3_options]     || {}
           @s3_permissions = @options[:s3_permissions] || :public_read
-          @s3_protocol    = @options[:s3_protocol]    || (@s3_permissions == :public_read ? 'http' : 'https')
+          @s3_protocol    = @options[:s3_protocol]    || :https
           @s3_headers     = @options[:s3_headers]     || {}
           @s3_host_alias  = @options[:s3_host_alias]
           @s3_endpoint    = @options[:s3_endpoint]    || "s3.amazonaws.com"

--- a/lib/dm-paperclip/storage/s3/aws_library.rb
+++ b/lib/dm-paperclip/storage/s3/aws_library.rb
@@ -28,7 +28,8 @@ module Paperclip
         end
 
         def s3_store(key,file)
-          @s3_bucket.objects[key].write(file)
+          opts = {acl: @s3_permissions}
+          @s3_bucket.objects[key].write(file, opts)
         end
 
         def s3_delete(key)


### PR DESCRIPTION
I ran into issues recently while upgrading a little sinatra project that my uploads were no longer being set to `public_read` when they got to Amazon.  I'm not sure if this is S3 policy changes since this gem was written or if something else changed under the hood, but this checkin seems to fix things (for me).  

I did not get tests running because the rest of the tooling (rake, test-unit etc) are really out of date and I wasn't quite ready to push things that far.  

Thought this might help some folks out, for anyone that is still using this gem.

Cheers
Jon